### PR TITLE
correct file include path

### DIFF
--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -404,7 +404,7 @@ class WP_Object_Cache {
 
 				// Load bundled Predis library
 				if ( ! class_exists( 'Predis\Client' ) ) {
-					require_once WP_CONTENT_DIR . '/plugins/redis-cache/includes/predis.php';
+					require_once WP_CONTENT_DIR . '/plugins/redis-object-cache/includes/predis.php';
 					Predis\Autoloader::register();
 				}
 


### PR DESCRIPTION
when the local client is `predis`, an attempt is made to include `/plugins/redis-cache/includes/predis.php`, seeing that this file path does not actually exist, a fatal error is thrown.

this corrects the file path to `/plugins/redis-object-cache/includes/predis.php`. i suggest to merge this upstream also if change is appropriate.
